### PR TITLE
fix: describe vsw with region para

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -86,7 +86,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	}
 
 	versionProvider := version.NewDefaultProvider(operator.KubernetesInterface, cache.New(alicache.KubernetesVersionTTL, alicache.DefaultCleanupInterval))
-	vSwitchProvider := vswitch.NewDefaultProvider(vpcClient, cache.New(alicache.DefaultTTL, alicache.DefaultCleanupInterval), cache.New(alicache.AvailableIPAddressTTL, alicache.DefaultCleanupInterval))
+	vSwitchProvider := vswitch.NewDefaultProvider(region, vpcClient, cache.New(alicache.DefaultTTL, alicache.DefaultCleanupInterval), cache.New(alicache.AvailableIPAddressTTL, alicache.DefaultCleanupInterval))
 	securityGroupProvider := securitygroup.NewDefaultProvider(region, ecsClient, cache.New(alicache.DefaultTTL, alicache.DefaultCleanupInterval))
 	imageProvider := imagefamily.NewDefaultProvider(region, ecsClient, ackClient, versionProvider, cache.New(alicache.DefaultTTL, alicache.DefaultCleanupInterval))
 	imageResolver := imagefamily.NewDefaultResolver(region, ecsClient, cache.New(alicache.InstanceTypeAvailableDiskTTL, alicache.DefaultCleanupInterval))

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -106,7 +106,7 @@ func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1alpha1.ECSNod
 
 func (p *DefaultProvider) Get(ctx context.Context, id string) (*Instance, error) {
 	describeInstancesRequest := &ecsclient.DescribeInstancesRequest{
-		RegionId:    &p.region,
+		RegionId:    tea.String(p.region),
 		InstanceIds: tea.String("[\"" + id + "\"]"),
 	}
 	runtime := &util.RuntimeOptions{}
@@ -143,7 +143,7 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 				Value: tea.String("owned"),
 			},
 		},
-		RegionId: p.ecsClient.RegionId,
+		RegionId: tea.String(p.region),
 	}
 
 	runtime := &util.RuntimeOptions{}
@@ -223,7 +223,7 @@ func (p *DefaultProvider) CreateTags(ctx context.Context, id string, tags map[st
 	}
 
 	addTagsRequest := &ecsclient.AddTagsRequest{
-		RegionId:     &p.region,
+		RegionId:     tea.String(p.region),
 		ResourceType: tea.String("instance"),
 		ResourceId:   tea.String(id),
 		Tag:          ecsTags,

--- a/pkg/providers/vswitch/vswitch.go
+++ b/pkg/providers/vswitch/vswitch.go
@@ -47,6 +47,8 @@ type Provider interface {
 }
 
 type DefaultProvider struct {
+	region string
+
 	sync.Mutex
 	vpcapi                  *vpc.Client
 	cache                   *cache.Cache
@@ -61,8 +63,9 @@ type VSwitch struct {
 	AvailableIPAddressCount int64
 }
 
-func NewDefaultProvider(vpcapi *vpc.Client, cache *cache.Cache, availableIPAddressCache *cache.Cache) *DefaultProvider {
+func NewDefaultProvider(region string, vpcapi *vpc.Client, cache *cache.Cache, availableIPAddressCache *cache.Cache) *DefaultProvider {
 	return &DefaultProvider{
+		region: region,
 		vpcapi: vpcapi,
 		cm:     pretty.NewChangeMonitor(),
 		// TODO: Remove cache when we utilize the resolved vSwitches from the ECSNodeClass.status
@@ -255,6 +258,7 @@ func (p *DefaultProvider) LivenessProbe(_ *http.Request) error {
 func (p *DefaultProvider) describeVSwitches(tags []*vpc.DescribeVSwitchesRequestTag, id *string, process func(*vpc.DescribeVSwitchesResponseBodyVSwitchesVSwitch)) error {
 	runtime := &util.RuntimeOptions{}
 	describeVSwitchesRequest := &vpc.DescribeVSwitchesRequest{
+		RegionId:  tea.String(p.region),
 		Tag:       tags,
 		VSwitchId: id,
 		PageSize:  tea.Int32(50),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

For HZ region, there will be follow error:
```
{"level":"ERROR","time":"2024-11-13T10:12:18.197Z","logger":"controller","message":"Reconciler error","commit":"f2ed819","controller":"nodeclass.status","controllerGroup":"karpenter.k8s.alibabacloud","controllerKind":"ECSNodeClass","ECSNodeClass":{"name":"defaultnodeclass"},"namespace":"","name":"defaultnodeclass","reconcileID":"9218c561-f101-4056-ae3a-85bb458fba42","error":"getting vSwitches, describing vSwitches {\"tags\":{\"karpenter.sh/discovery\":\"ack-alert-poc\"}}, SDKError:\n   StatusCode: 400\n   Code: MissingParameter\n   Message: code: 400, The input parameter \"regionId or vpcInstanceId\" that is mandatory for processing this request is not supplied. request id: AA9C3358-902E-5ECC-BA6C-C799936E4411\n   Data: {\"Code\":\"MissingParameter\",\"HostId\":\"vpc.aliyuncs.com\",\"Message\":\"The input parameter \\\"regionId or vpcInstanceId\\\" that is mandatory for processing this request is not supplied.\",\"Recommend\":\"https://api.aliyun.com/troubleshoot?q=MissingParameter&product=Vpc&requestId=AA9C3358-902E-5ECC-BA6C-C799936E4411\",\"RequestId\":\"AA9C3358-902E-5ECC-BA6C-C799936E4411\",\"statusCode\":400}\n"}
```

We should set the regionid para

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```