### PR TITLE
chore: use SecurityGroupIds instad of SecurityGroupId for ProvisionGroup

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -533,14 +533,10 @@ func (p *DefaultProvider) getProvisioningGroup(ctx context.Context, nodeClass *v
 		AutoProvisioningGroupType:       tea.String("instant"),
 		LaunchConfiguration: &ecsclient.CreateAutoProvisioningGroupRequestLaunchConfiguration{
 			// TODO: we should set image id for each instance types after alibabacloud supports
-			ImageId:          tea.String(imageID),
-			SecurityGroupIds: securityGroupIDs,
-			UserData:         tea.String(userData),
-
-			// TODO: AutoProvisioningGroup is not compatible with SecurityGroupIds, waiting for Aliyun developers to fix it,
-			// so here we only take the first one.
+			ImageId:                    tea.String(imageID),
+			UserData:                   tea.String(userData),
 			ResourceGroupId:            tea.String(nodeClass.Spec.ResourceGroupID),
-			SecurityGroupId:            securityGroupIDs[0],
+			SecurityGroupIds:           securityGroupIDs,
 			SystemDiskSize:             systemDisk.Size,
 			SystemDiskPerformanceLevel: systemDisk.PerformanceLevel,
 			Tag:                        reqTags,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
remove the todo, the bug is fixed by alibabacloud

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```