### PR TITLE
fix: get image status even it's expired

### DIFF
--- a/pkg/providers/imagefamily/image.go
+++ b/pkg/providers/imagefamily/image.go
@@ -169,8 +169,9 @@ func (p *DefaultProvider) getImagesWithAlias(k8sVersion string) (Images, error) 
 
 func (p *DefaultProvider) getImagesWithID(id string) (Images, error) {
 	req := &ecs.DescribeImagesRequest{
-		RegionId: tea.String(p.region),
-		ImageId:  tea.String(id),
+		RegionId:    tea.String(p.region),
+		ImageId:     tea.String(id),
+		ShowExpired: tea.Bool(true),
 	}
 
 	resp, err := p.ecsClient.DescribeImages(req)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Sometimes, alibabacloud will update the image to a newer version. If we do not use showExpired para, we clould not resolve the images.

This only happen when the user specify the image id

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
none

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```