### PR TITLE
fix: set default disk categories and size

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.alibabacloud_ecsnodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.alibabacloud_ecsnodeclasses.yaml
@@ -262,6 +262,13 @@ spec:
                 description: SystemDisk to be applied to provisioned nodes.
                 properties:
                   categories:
+                    default:
+                    - cloud
+                    - cloud_efficiency
+                    - cloud_ssd
+                    - cloud_essd
+                    - cloud_auto
+                    - cloud_essd_entry
                     description: |-
                       The category of the system disk (for example, cloud and cloud_ssd).
                       Different ECS is compatible with different disk category, using array to maximize ECS creation success.
@@ -286,6 +293,7 @@ spec:
                     - PL3
                     type: string
                   size:
+                    default: 20
                     description: |-
                       The size of the system disk. Unit: GiB.
                       Valid values:

--- a/pkg/apis/v1alpha1/ecsnodeclass.go
+++ b/pkg/apis/v1alpha1/ecsnodeclass.go
@@ -209,6 +209,7 @@ type SystemDisk struct {
 	// Different ECS is compatible with different disk category, using array to maximize ECS creation success.
 	// Valid values:"cloud", "cloud_efficiency", "cloud_ssd", "cloud_essd", "cloud_auto", and "cloud_essd_entry"
 	// +kubebuilder:validation:Items=Enum=cloud;cloud_efficiency;cloud_ssd;cloud_essd;cloud_auto;cloud_essd_entry
+	// +kubebuilder:default:={"cloud","cloud_efficiency","cloud_ssd","cloud_essd","cloud_auto","cloud_essd_entry"}
 	// +optional
 	Categories []string `json:"categories,omitempty"`
 	// The size of the system disk. Unit: GiB.
@@ -217,6 +218,7 @@ type SystemDisk struct {
 	//   * If you set Category to other disk categories: 20 to 2048.
 	//
 	// +kubebuilder:validation:XValidation:message="size invalid",rule="self >= 20"
+	// +kubebuilder:default:=20
 	// +optional
 	Size *int32 `json:"size,omitempty"`
 	// The performance level of the ESSD to use as the system disk. Default value: PL0.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If users only set disk size, the categories will be empty, which is not correct

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```