### PR TITLE
fix: select nodepool id when describe cluster attach scripts

### DIFF
--- a/pkg/providers/ack/ack.go
+++ b/pkg/providers/ack/ack.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 
@@ -105,6 +106,51 @@ func (p *DefaultProvider) GetClusterCNI(_ context.Context) (string, error) {
 	return p.clusterCNI, nil
 }
 
+// Get the ID of the target nodepool id when DescribeClusterAttachScriptsRequest.
+// If there is no default nodepool, select the nodepool with the most HealthyNodes.
+//
+//nolint:gocyclo
+func (p *DefaultProvider) getTargetNodePoolID(ctx context.Context) (*string, error) {
+	resp, err := p.ackClient.DescribeClusterNodePools(tea.String(p.clusterID), &ackclient.DescribeClusterNodePoolsRequest{})
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to describe cluster nodepools")
+		return nil, err
+	}
+	if resp == nil || resp.Body == nil || resp.Body.Nodepools == nil {
+		return nil, fmt.Errorf("empty describe cluster nodepools response")
+	}
+	if len(resp.Body.Nodepools) == 0 {
+		return nil, fmt.Errorf("no nodepool found")
+	}
+
+	nodepools := resp.Body.Nodepools
+	sort.Slice(nodepools, func(i, j int) bool {
+		if nodepools[i].NodepoolInfo == nil || nodepools[j].NodepoolInfo == nil {
+			return false
+		}
+
+		if nodepools[i].NodepoolInfo.IsDefault != nil && nodepools[j].NodepoolInfo.IsDefault != nil {
+			if *nodepools[i].NodepoolInfo.IsDefault && !*nodepools[j].NodepoolInfo.IsDefault {
+				return true
+			}
+			if !*nodepools[i].NodepoolInfo.IsDefault && *nodepools[j].NodepoolInfo.IsDefault {
+				return false
+			}
+		}
+
+		if nodepools[i].Status == nil || nodepools[j].Status == nil || nodepools[i].Status.HealthyNodes == nil || nodepools[j].Status.HealthyNodes == nil {
+			return false
+		}
+		return *nodepools[i].Status.HealthyNodes > *nodepools[j].Status.HealthyNodes
+	})
+
+	targetNodepool := nodepools[0]
+	if targetNodepool.NodepoolInfo == nil {
+		return nil, fmt.Errorf("target describe cluster nodepool is empty")
+	}
+	return targetNodepool.NodepoolInfo.NodepoolId, nil
+}
+
 func (p *DefaultProvider) GetNodeRegisterScript(ctx context.Context,
 	capacityType string,
 	nodeClaim *karpv1.NodeClaim,
@@ -114,8 +160,19 @@ func (p *DefaultProvider) GetNodeRegisterScript(ctx context.Context,
 		return p.resolveUserData(cachedScript.(string), labels, nodeClaim, kubeletCfg), nil
 	}
 
+	nodepoolID, err := p.getTargetNodePoolID(ctx)
+	if err != nil {
+		// Don't return here, we can process when there is no default cluster id.
+		// We need to try to obtain a usable nodepool ID in order to get the cluster attach scripts.
+		// One known scenario is on an ACK cluster with version 1.24, where the user deleted the default nodepool and
+		// created a nodepool with a containerd runtime. The DescribeClusterAttachScriptsRequest api will use the
+		// CRI configuration of the deleted default nodepool, which might be using the Docker runtime.
+		// This could result in nodes failing to register to the new cluster.
+		log.FromContext(ctx).Error(err, "Failed to get default nodepool id")
+	}
 	reqPara := &ackclient.DescribeClusterAttachScriptsRequest{
 		KeepInstanceName: tea.Bool(true),
+		NodepoolId:       nodepoolID,
 	}
 	resp, err := p.ackClient.DescribeClusterAttachScripts(tea.String(p.clusterID), reqPara)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We encountered a situation where the `DescribeClusterAttachScriptsRequest` will **use the default nodepool when the NodepoolID is not provided**. However, in some cases, the default nodepool may have been deleted, but `DescribeClusterAttachScriptsRequest` will still use the CRI configuration of the default nodepool. In an ACK cluster with version 1.24, if the default nodepool was originally created with Docker Runtime but was later deleted and replaced with a new nodepool using Containerd Runtime, this could cause nodes to fail to register to the cluster. This is because Docker Runtime only supports clusters of version 1.22 and below now.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
To call `DescribeClusterAttachScriptsRequest`, Karpenter need to provide the NodePoolID now, preferably selecting the default NodePool. If you are using Karpenter deployed with minimal permissions after account transfer, you need to grant your RAM User the permission cs:DescribeClusterNodePools. This will resolve the issue where nodes created by older clusters may fail to register with the cluster in some cases.
```