### PR TITLE
modify cluster-type usage

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -53,7 +53,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.BoolVar(&o.Interruption, "interruption", env.WithDefaultBool("INTERRUPTION", true), "Enable interruption handling.")
 	fs.BoolVar(&o.TelemetryShare, "telemetry-share", env.WithDefaultBool("TELEMETRY_SHARE", true), "Enable telemetry sharing.")
 	fs.IntVar(&o.APGCreationQPS, "apg-qps", int(env.WithDefaultInt64("APG_CREATION_QPS", 100)), "The QPS limit for creating AutoProvisionGroup.")
-	fs.StringVar(&o.ClusterType, "cluster-type", env.WithDefaultString("CLUSTER_TYPE", "ACKManaged"), "Type of cluster, which specifies the method to generate userdata. The default is ACKManaged, with an option for Custom configuration.")
+	fs.StringVar(&o.ClusterType, "cluster-type", env.WithDefaultString("CLUSTER_TYPE", "ACKManaged"), "Type of cluster, which specifies the method to generate userdata. The default is ACKManaged, with an option for Custom configuration. If your cluster-type is not default or ACKManaged, you need to add taint(karpenter.sh/unregistered:NoExecute) before the node is ready")
 }
 
 func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If the cluster type is ACKManaged and a new node is not tainted with karpenter.sh/unregistered:NoExecute, then the node will not be managed by Karpenter afterward.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```