### PR TITLE
fix imageSelectorTerms must match family format

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.alibabacloud_ecsnodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.alibabacloud_ecsnodeclasses.yaml
@@ -101,7 +101,7 @@ spec:
                       x-kubernetes-validations:
                       - message: '''alias'' is improperly formatted, must match the
                           format ''family'''
-                        rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                        rule: self.matches('^[a-zA-Z0-9]*$')
                       - message: 'family is not supported, must be one of the following:
                           ''AlibabaCloudLinux3,ContainerOS'''
                         rule: self.find('^[^@]+') in ['AlibabaCloudLinux3', 'ContainerOS']


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
ECSNodeClass cannot be created successfully when AlibabaCloudLinux3 or ContainerOS is specified, but it can be created successfully when AlibabaCloudLinux3@latest is used, but karpenter throws the error: "unsupported image family AlibabaCloudLinux3@latest"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
action required
```