### PR TITLE
fix: re-enqueue not too offen if error happened

### DIFF
--- a/pkg/controllers/nodeclass/status/controller.go
+++ b/pkg/controllers/nodeclass/status/controller.go
@@ -104,11 +104,11 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1alpha1.ECSNodeC
 			errs = multierr.Append(errs, client.IgnoreNotFound(err))
 		}
 	}
-
-	if errs != nil {
-		return reconcile.Result{}, errs
+	if result.Min(results...).RequeueAfter > 0 {
+		return result.Min(results...), nil
 	}
-	return result.Min(results...), nil
+
+	return reconcile.Result{}, errs
 }
 
 func (c *Controller) Register(_ context.Context, m manager.Manager) error {

--- a/pkg/controllers/nodeclass/status/image.go
+++ b/pkg/controllers/nodeclass/status/image.go
@@ -37,7 +37,7 @@ func (i *Image) Reconcile(ctx context.Context, nodeClass *v1alpha1.ECSNodeClass)
 	images, err := i.imageProvider.List(ctx, nodeClass)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to list images")
-		return reconcile.Result{}, err
+		return reconcile.Result{RequeueAfter: time.Second * 30}, err
 	}
 
 	if len(images) == 0 {

--- a/pkg/controllers/nodeclass/status/securitygroup.go
+++ b/pkg/controllers/nodeclass/status/securitygroup.go
@@ -34,7 +34,7 @@ type SecurityGroup struct {
 func (sg *SecurityGroup) Reconcile(ctx context.Context, nodeClass *v1alpha1.ECSNodeClass) (reconcile.Result, error) {
 	securityGroups, err := sg.securityGroupProvider.List(ctx, nodeClass)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("getting security groups, %w", err)
+		return reconcile.Result{RequeueAfter: time.Second * 30}, fmt.Errorf("getting security groups, %w", err)
 	}
 	if len(securityGroups) == 0 && len(nodeClass.Spec.SecurityGroupSelectorTerms) > 0 {
 		nodeClass.Status.SecurityGroups = nil

--- a/pkg/controllers/nodeclass/status/vswitch.go
+++ b/pkg/controllers/nodeclass/status/vswitch.go
@@ -37,7 +37,7 @@ type VSwitch struct {
 func (v *VSwitch) Reconcile(ctx context.Context, nodeClass *v1alpha1.ECSNodeClass) (reconcile.Result, error) {
 	vSwitches, err := v.vSwitchProvider.List(ctx, nodeClass)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("getting vSwitches, %w", err)
+		return reconcile.Result{RequeueAfter: time.Second * 30}, fmt.Errorf("getting vSwitches, %w", err)
 	}
 	if len(vSwitches) == 0 {
 		nodeClass.Status.VSwitches = nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fix: re-enqueue not too offen if error happened

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #none

#### Special notes for your reviewer:
fix: re-enqueue not too offen if error happened

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```